### PR TITLE
support remote url

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -2,10 +2,11 @@ package cli
 
 import "flag"
 
-func ParseArgs() (username, password string, port int) {
+func ParseArgs() (username, password, url string, port int) {
 	flag.IntVar(&port, "port", 9091, "rpc port")
 	flag.StringVar(&username, "username", "", "username")
 	flag.StringVar(&password, "password", "", "password")
+	flag.StringVar(&url, "url", "http://localhost", "rpc url")
 	flag.Parse()
 	return
 }

--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/Murtaza-Udaipurwala/trt/cli"
 	"github.com/Murtaza-Udaipurwala/trt/core"
@@ -9,10 +10,14 @@ import (
 )
 
 func main() {
-	username, password, port := cli.ParseArgs()
+	username, password, url, port := cli.ParseArgs()
+
+	if !strings.HasPrefix(url, "http") {
+		url = "http://" + url
+	}
 
 	session := core.Session{}
-	session.URL = fmt.Sprintf("http://127.0.0.1:%d/transmission/rpc", port)
+	session.URL = fmt.Sprintf("%s:%d/transmission/rpc", url, port)
 	session.Username = username
 	session.Password = password
 	session.CompileRegex()


### PR DESCRIPTION
RPC url can now be passed using --url flag. Defaults to http://localhost. (#2) 